### PR TITLE
selectedMonth feature

### DIFF
--- a/webapp/src/app/championship.service.ts
+++ b/webapp/src/app/championship.service.ts
@@ -7,7 +7,8 @@ import { Championship } from './models/championship';
 export class ChampionshipService {
 
 	private url = '/championships';
-	private currentChampionhip: Championship;
+	private currentChampionship: Championship;
+	private selectedChampionship: Championship;
 
 	constructor(private api: ApiRequestService) { }
 
@@ -16,6 +17,7 @@ export class ChampionshipService {
 	}
 
 	update(id, championship: Championship) : Observable<Championship> {
+		delete championship._id;
 		return this.api.post(this.url + '/' + id, championship);
 	}
 
@@ -39,11 +41,19 @@ export class ChampionshipService {
 		return this.api.get(this.url + '?month=' + month + '&year=' + year);
 	}
 
+	setSelectedChampionship(championship: Championship) {
+		this.selectedChampionship = championship;
+	}
+
+	getSelectedChampionship() {
+		return this.selectedChampionship;
+	}
+
 	setCurrentChampionship(championship: Championship) {
-		this.currentChampionhip = championship;
+		this.currentChampionship = championship;
 	}
 
 	getCurrentChampionship() {
-		return this.currentChampionhip;
+		return this.currentChampionship;
 	}
 }

--- a/webapp/src/app/insert-match/insert-match.component.ts
+++ b/webapp/src/app/insert-match/insert-match.component.ts
@@ -101,13 +101,12 @@ export class InsertMatchComponent implements OnInit, OnChanges {
 	tryCreateMatch() {
 		this.match.isFinal = this.isFinal;
 
-		// TODO: get championship of month:
-		if (!this.championshipService.getCurrentChampionship()) {
-			this.error = { description: 'Verifique se há um campeonato criado.' };
+		if (!this.championshipService.getSelectedChampionship()) {
+			this.error = { description: 'Verifique se há um campeonato criado neste mês.' };
 			return false;
 		}
 
-		this.match.championship = this.championshipService.getCurrentChampionship();
+		this.match.championship = this.championshipService.getSelectedChampionship();
 
 		this.matchService.getFinalFromChampionship(this.match.championship._id).toPromise()
 			.then(response => {

--- a/webapp/src/app/navigation-bar/navigation-bar.component.ts
+++ b/webapp/src/app/navigation-bar/navigation-bar.component.ts
@@ -68,7 +68,17 @@ export class NavigationBarComponent implements OnInit {
 	}
 
 	createMatch() {
-		this.matchModalActions.emit({action:"modal", params:['open']});
+		if (!this.championshipService.getSelectedChampionship()) {
+			if (!window.confirm("Este mês ainda não tem um campeonato criado. Deseja criar?")) {
+				return;
+			} else {
+				if (this.createSeason()) {
+					this.matchModalActions.emit({action:"modal", params:['open']});
+				}
+			}
+		} else {
+			this.matchModalActions.emit({action:"modal", params:['open']});
+		}
 	}
 
 	teamPick() {
@@ -110,24 +120,26 @@ export class NavigationBarComponent implements OnInit {
 	createSeason() {
 		if (!window.confirm("ATENÇÃO!! Tem certeza que quer iniciar um novo campeonato?" +
 			" O campeonato atual não poderá mais ser alterado!")) {
-			return;
+			return false;
 		}
 
 		if (this.championshipService.getCurrentChampionship()) {
 			this.createSeasonBasedOnCurrentSeason(this.championshipService.getCurrentChampionship());
-			return;
+			return true;
 		}
 
 		this.championshipService.getCurrent().subscribe((current: Championship[]) => {
 			if (current.length == 0) {
 				var date = new Date();
 				this.insertChampionship(date.getMonth() + 1, date.getFullYear());
-				return;
+				return true;
 			}
 			var currentSeason = current[0];
 			this.createSeasonBasedOnCurrentSeason(currentSeason);
+			return true;
 		}, (error: any) => {
 			console.error(error);
+			return false;
 		});
 	}
 

--- a/webapp/src/app/season-selector/season-selector.component.ts
+++ b/webapp/src/app/season-selector/season-selector.component.ts
@@ -33,6 +33,7 @@ export class SeasonSelectorComponent implements OnInit {
 					return;
 				}
 				this.championshipService.setCurrentChampionship(championships[0]);
+				this.championshipService.setSelectedChampionship(championships[0]);
 			});
 		}
 
@@ -71,6 +72,11 @@ export class SeasonSelectorComponent implements OnInit {
 
 	previousMonth() {
 		this.date = this.sumMonth(this.date, -1)
+
+		this.championshipService.getByMonth(this.date.getMonth() + 1, this.date.getFullYear()).subscribe((championships) => {
+			this.championshipService.setSelectedChampionship(championships[0]);
+		});
+
 		if(this.tab == 0)
 			this.router.navigateByUrl('season/standings/' + (this.date.getMonth() + 1) + '/' + this.date.getFullYear());
 		else
@@ -79,6 +85,11 @@ export class SeasonSelectorComponent implements OnInit {
 
 	nextMonth() {
 		this.date = this.sumMonth(this.date, 1)
+
+		this.championshipService.getByMonth(this.date.getMonth() + 1, this.date.getFullYear()).subscribe((championships) => {
+			this.championshipService.setSelectedChampionship(championships[0]);
+		});
+
 		if(this.tab == 0)
 			this.router.navigateByUrl('season/standings/' + (this.date.getMonth() + 1) + '/' + this.date.getFullYear());
 		else


### PR DESCRIPTION
The long awaited feature of CREATING FINALS FOR A DIFFERENT MONTH THAN THE CURRENT ONE!!111eleven!!

Now the matches are created on the month that is being shown, and they are only created if:
- A championship exists on that month (it is possible to create a championship on the same flow) and;
- the championship of the that month does not have a final registered to it.

And that's basically it!

I hope you guys like it and sorry for the branch name, I ended up changing the implementation that I had planned when I named the branch :stuck_out_tongue_closed_eyes: 